### PR TITLE
feat: Implement medical QA system with live Wikipedia fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,124 @@
+# Medical Question Answering System with Live Wikipedia Fetching
+
+## 1. Overview
+
+This project implements a question answering system specifically designed for the medical domain, using the MedQA (USMLE-style) dataset. It leverages live Wikipedia fetching to gather relevant information dynamically for each question. The system preprocesses questions, retrieves articles from Wikipedia, uses an extractive QA model to find potential answers in these articles, and then selects the best multiple-choice option.
+
+## 2. Project Structure
+
+```
+/project_root
+  main.py             # Main orchestration script
+  data_loader.py      # Loads MedQA dataset
+  preprocessing.py    # Text preprocessing utilities (clean, tokenize, NER)
+  retriever.py        # Fetches relevant Wikipedia articles
+  reader.py           # Extracts answer spans from articles using a QA model
+  answer_selector.py  # Selects the best multiple-choice option
+  evaluator.py        # Evaluates the system's accuracy
+  config.py           # Configuration settings (model names, paths, etc.)
+  requirements.txt    # Python dependencies
+  README.md           # This file
+  /models/            # Stores downloaded ML models
+  /wikipedia_cache/   # Caches downloaded Wikipedia articles
+  /index/             # Stores FAISS index files (if pre-built title index is used)
+```
+
+## 3. Setup
+
+### 3.1. Prerequisites
+*   Python 3.8+
+*   Access to the internet (for downloading models, datasets, and fetching Wikipedia articles live)
+
+### 3.2. Installation
+1.  **Clone the repository (if applicable):**
+    ```bash
+    # git clone <repository_url>
+    # cd <repository_directory>
+    ```
+2.  **Create a virtual environment (recommended):**
+    ```bash
+    python -m venv venv
+    source venv/bin/activate  # On Windows: venv\Scripts\activate
+    ```
+3.  **Install dependencies:**
+    ```bash
+    pip install -r requirements.txt
+    ```
+    This will install all necessary Python packages, including PyTorch, Transformers, spaCy, NLTK, Scikit-learn, Wikipedia, etc.
+
+### 3.3. Model and Data Download
+The system requires several machine learning models (Sentence Transformer, QA model, spaCy language model) and NLTK data.
+
+*   **Automated Download via `main.py`:**
+    The first time you run `main.py`, it will attempt to download and save all required models to the `./models/` directory and NLTK data if not found.
+    ```bash
+    python main.py --subset_eval # Using --subset_eval for a quicker first run
+    ```
+    Ensure you have an active internet connection.
+
+*   **Manual SpaCy Model Download (if needed):**
+    If the automated spaCy model download fails, you can try it manually:
+    ```bash
+    python -m spacy download en_core_web_sm
+    ```
+    (The `config.py` specifies `en_core_web_sm`. If you change it, download the corresponding model).
+
+## 4. Running the System
+
+The main script for running the QA pipeline is `main.py`.
+
+### 4.1. Full Evaluation
+To run the system on the full MedQA test dataset:
+```bash
+python main.py
+```
+This will process all questions, fetch Wikipedia articles live, and evaluate accuracy. This can take a significant amount of time and requires a stable internet connection.
+
+### 4.2. Subset Evaluation
+For a quicker test or debugging, run on a subset of questions (default is 1000, defined in `config.py`):
+```bash
+python main.py --subset_eval
+```
+
+### 4.3. (Optional) Building Wikipedia Title Index
+The retriever has functionality to build a FAISS index of Wikipedia titles/snippets if you want to experiment with a pre-defined set of relevant pages. This is not the primary mode of operation for live fetching but is available.
+```bash
+python main.py --build_title_index
+```
+This requires internet access to fetch initial search results for index creation.
+
+## 5. Modules
+
+*   **`main.py`**: Orchestrates the entire QA pipeline: loads data, initializes components, processes questions, and triggers evaluation. Handles model downloads.
+*   **`data_loader.py`**: Responsible for loading the MedQA dataset from Hugging Face's `datasets` library.
+*   **`preprocessing.py`**: Contains functions for text cleaning (lowercasing, punctuation removal), tokenization, stopword removal, lemmatization, and Named Entity Recognition (NER) using spaCy.
+*   **`retriever.py`**: Given a question, it preprocesses the query, augments it with NER entities and TF-IDF keywords, searches Wikipedia via its API, ranks search results using semantic similarity, and fetches the full text of the top N articles. Caches downloaded articles.
+*   **`reader.py`**: Takes the retrieved Wikipedia articles and the question. It uses an extractive Question Answering (QA) model (e.g., DistilBERT-SQuAD) to identify potential answer spans within the text of each article. Handles chunking of long articles.
+*   **`answer_selector.py`**: Aggregates all candidate answer spans from the `Reader`. It then compares each candidate to the 4 multiple-choice options provided by the MedQA question, using exact match, fuzzy string matching, and semantic similarity. It selects the MedQA option with the highest aggregated score.
+*   **`evaluator.py`**: Calculates the system's performance, primarily accuracy (correct answer selection rate).
+*   **`config.py`**: Centralized configuration for model names, file paths, API parameters, and other settings.
+
+## 6. Expected Output
+
+When you run `main.py`, you will see logging output for each question being processed, including:
+*   The question and options.
+*   The constructed Wikipedia search query.
+*   Titles of retrieved Wikipedia pages.
+*   Candidate answers extracted by the reader.
+*   The final selected answer option.
+
+At the end of the run, evaluation results will be printed:
+```
+--- Evaluation Results ---
+Total Questions: [Number of questions processed]
+Correctly Answered: [Number of correct answers]
+Accuracy: [Accuracy score, e.g., 0.XXXX]
+
+--- Project Work Complete ---
+Final Accuracy: [Accuracy score, e.g., 0.XXXX]
+```
+
+## 7. Notes
+*   The system relies on live calls to the Wikipedia API. Ensure your network allows this. Rate limiting or IP blocks from Wikipedia are a potential risk if making too many requests too quickly (though the `wikipedia` library and `requests` sessions usually handle this gracefully for moderate use).
+*   Performance (accuracy) will depend on the quality of retrieved articles, the QA model's capabilities, and the effectiveness of the answer selection logic.
+```

--- a/data_loader.py
+++ b/data_loader.py
@@ -2,15 +2,34 @@ from datasets import load_dataset
 import os
 import json
 from config import MEDQA_DATASET_NAME
+from datasets import Dataset # For type hinting
 
-def load_medqa_dataset(split="train"):
+def load_medqa_dataset(split: str = "train") -> Dataset | None:
     """
-    Loads the MedQA-USMLE-4-options dataset from Hugging Face. [cite: 130]
+    Loads a specified split of the MedQA-USMLE-4-options dataset from Hugging Face.
+
+    Args:
+        split (str, optional): The dataset split to load (e.g., "train", "test",
+                               "validation"). Defaults to "train".
+
+    Returns:
+        datasets.Dataset | None: The loaded Hugging Face Dataset object, or None
+                                 if loading fails.
     """
     print(f"Loading MedQA dataset (split: {split})...")
-    dataset = load_dataset(MEDQA_DATASET_NAME, split=split) 
-    print(f"Dataset loaded. Number of examples: {len(dataset)}")
-    return dataset
+    try:
+        dataset = load_dataset(MEDQA_DATASET_NAME, name="US", split=split) # Added name="US" as per HF dataset viewer for this dataset
+        print(f"Dataset '{MEDQA_DATASET_NAME}' (split: {split}) loaded successfully. Number of examples: {len(dataset)}")
+        return dataset
+    except FileNotFoundError:
+        print(f"Error: Dataset {MEDQA_DATASET_NAME} not found. It might be a configuration issue or the dataset was removed from Hugging Face Hub.")
+        return None
+    except ConnectionError:
+        print(f"Error: Could not connect to Hugging Face Hub to download dataset {MEDQA_DATASET_NAME}. Please check your internet connection.")
+        return None
+    except Exception as e:
+        print(f"An unexpected error occurred while loading dataset {MEDQA_DATASET_NAME} (split: {split}): {e}")
+        return None
 
 # No load_wikipedia_data() function here anymore, as it's fetched on demand.
 

--- a/evaluator.py
+++ b/evaluator.py
@@ -1,12 +1,33 @@
 class Evaluator:
-    def evaluate(self, predictions, ground_truth_labels):
+    """
+    Handles the evaluation of the Question Answering system's predictions.
+    Currently, it calculates accuracy based on predicted answer option indices
+    against ground truth labels.
+    """
+    def evaluate(self, predictions: list[int], ground_truth_labels: list[int]) -> float:
         """
-        Calculates accuracy. [cite: 300, 301]
-        predictions: List of predicted answer option indices (0-3).
-        ground_truth_labels: List of true answer option indices (0-3).
+        Calculates the accuracy of predictions against ground truth labels.
+
+        Args:
+            predictions (list[int]): A list of predicted answer option indices (e.g., 0-3).
+            ground_truth_labels (list[int]): A list of true answer option indices (e.g., 0-3).
+
+        Returns:
+            float: The calculated accuracy, a value between 0.0 and 1.0.
+
+        Raises:
+            ValueError: If the lengths of `predictions` and `ground_truth_labels` lists
+                        do not match.
         """
+        if not isinstance(predictions, list) or not isinstance(ground_truth_labels, list):
+            raise TypeError("Predictions and ground_truth_labels must be lists.")
+
         if len(predictions) != len(ground_truth_labels):
             raise ValueError("Length of predictions and ground truth labels must be the same.")
+
+        if not predictions: # Handles empty list case
+            print("Warning: Empty predictions list provided. Accuracy is 0.")
+            return 0.0
 
         correct_count = 0
         for pred, gt in zip(predictions, ground_truth_labels):

--- a/main.py
+++ b/main.py
@@ -9,11 +9,25 @@ from config import SUBSET_EVAL_SIZE, MAX_WIKIPEDIA_PAGES_PER_QUESTION, WIKIPEDIA
                    SENTENCE_TRANSFORMER_MODEL, QA_MODEL_NAME, SPACY_MODEL_NAME, \
                    SENTENCE_TRANSFORMER_MODEL_PATH, QA_MODEL_PATH # Added for pre-downloading in main
 import os
-import torch
+# import torch # torch is imported by specific modules if/when needed, not directly used in main.py's top level
 from transformers import AutoTokenizer, AutoModel, AutoModelForQuestionAnswering # Added for pre-downloading
+import spacy # For SpaCy model download check
 
 def pre_download_all_models():
-    """Ensures all necessary models are downloaded locally."""
+    """
+    Ensures all necessary Hugging Face Transformer models and SpaCy language models
+    are downloaded and cached locally.
+
+    This function attempts to download:
+    - Sentence Transformer model (for retriever and answer selector).
+    - Question Answering (QA) model (for reader).
+    - SpaCy language model (for preprocessing).
+
+    Models are saved to paths defined in `config.py`.
+    Errors during download are caught and reported, allowing the script to
+    potentially continue if some models are already present or if manual
+    download is preferred.
+    """
     print("Ensuring all models are pre-downloaded...")
     
     # Sentence Transformer
@@ -49,6 +63,25 @@ def pre_download_all_models():
 
 
 def main():
+    """
+    Main function to run the Medical Question Answering System.
+
+    Orchestrates the entire pipeline:
+    1. Parses command-line arguments for evaluation mode (full/subset) and
+       optional Wikipedia title index building.
+    2. Ensures necessary directories and models are set up/downloaded.
+    3. Initializes the Retriever, Reader, AnswerSelector, and Evaluator components.
+    4. Loads the MedQA dataset.
+    5. Iterates through questions, performing retrieval, reading, and answer selection.
+    6. Handles errors gracefully at each stage for each question, allowing the
+       pipeline to continue with the next question.
+    7. Evaluates the system's performance (accuracy) and prints the results.
+
+    Command-line arguments:
+        --subset_eval: Evaluate on a smaller subset of questions for quick testing.
+        --build_title_index: Build a FAISS index of Wikipedia titles (optional,
+                             requires internet for initial data fetching).
+    """
     parser = argparse.ArgumentParser(description="Medical Question Answering System")
     parser.add_argument("--subset_eval", action="store_true",
                         help=f"Evaluate on a subset of {SUBSET_EVAL_SIZE} questions instead of all.") 

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -35,42 +35,123 @@ except OSError:
 stop_words = set(stopwords.words('english'))
 lemmatizer = WordNetLemmatizer()
 
-def clean_text(text):
-    """Removes punctuation, numbers, and converts to lowercase."""
+def clean_text(text: str) -> str:
+    """
+    Cleans text by converting to lowercase and removing punctuation and numbers.
+
+    Args:
+        text (str): The input string.
+
+    Returns:
+        str: The cleaned string, containing only lowercase letters and spaces.
+    """
+    if not isinstance(text, str):
+        # Or raise TypeError, but for this project, returning empty string might be safer if called in a pipeline
+        print(f"Warning: clean_text received non-string input: {type(text)}. Returning empty string.")
+        return ""
     text = text.lower()
     text = re.sub(r'[^a-z\s]', '', text) # Keep only letters and spaces
     return text
 
-def tokenize_text(text):
-    """Tokenizes text into words."""
+def tokenize_text(text: str) -> list[str]:
+    """
+    Tokenizes text into words using NLTK.
+
+    Args:
+        text (str): The input string.
+
+    Returns:
+        list[str]: A list of word tokens.
+    """
+    if not isinstance(text, str):
+        print(f"Warning: tokenize_text received non-string input: {type(text)}. Returning empty list.")
+        return []
     return nltk.word_tokenize(text)
 
-def remove_stopwords(tokens):
-    """Removes common stopwords from a list of tokens."""
+def remove_stopwords(tokens: list[str]) -> list[str]:
+    """
+    Removes common English stopwords from a list of tokens.
+
+    Args:
+        tokens (list[str]): A list of word tokens.
+
+    Returns:
+        list[str]: A list of tokens with stopwords removed.
+    """
+    if not isinstance(tokens, list):
+        print(f"Warning: remove_stopwords received non-list input: {type(tokens)}. Returning empty list.")
+        return []
     return [word for word in tokens if word not in stop_words]
 
-def lemmatize_tokens(tokens):
-    """Lemmatizes tokens to their base form."""
+def lemmatize_tokens(tokens: list[str]) -> list[str]:
+    """
+    Lemmatizes tokens to their base form using WordNetLemmatizer.
+
+    Args:
+        tokens (list[str]): A list of word tokens.
+
+    Returns:
+        list[str]: A list of lemmatized tokens.
+    """
+    if not isinstance(tokens, list):
+        print(f"Warning: lemmatize_tokens received non-list input: {type(tokens)}. Returning empty list.")
+        return []
     return [lemmatizer.lemmatize(word) for word in tokens]
 
-def preprocess_text(text, perform_lemmatization=True):
+def preprocess_text(text: str, perform_lemmatization: bool = True) -> str:
     """
-    Applies a full preprocessing pipeline.
+    Applies a full preprocessing pipeline to the input text.
+
+    The pipeline consists of:
+    1. Cleaning (lowercase, remove punctuation/numbers).
+    2. Tokenization.
+    3. Stopword removal.
+    4. Lemmatization (optional).
+
+    Args:
+        text (str): The input string.
+        perform_lemmatization (bool, optional): Whether to perform lemmatization.
+                                                 Defaults to True.
+
+    Returns:
+        str: The preprocessed text as a single string with tokens joined by spaces.
+             Returns an empty string if input is not a string.
     """
-    text = clean_text(text)
-    tokens = tokenize_text(text)
+    if not isinstance(text, str):
+        print(f"Warning: preprocess_text received non-string input: {type(text)}. Returning empty string.")
+        return ""
+
+    cleaned_text = clean_text(text)
+    tokens = tokenize_text(cleaned_text)
     tokens = remove_stopwords(tokens)
     if perform_lemmatization:
         tokens = lemmatize_tokens(tokens)
     return " ".join(tokens)
 
-def extract_medical_entities_spacy(text):
+def extract_medical_entities_spacy(text: str) -> list[tuple[str, str]]:
     """
-    Extracts named entities from text using spaCy. [cite: 140]
-    This function is crucial for identifying keywords for Wikipedia searches. [cite: 186]
+    Extracts named entities from text using the loaded spaCy model.
+
+    Identifies entities like diseases, drugs, anatomical parts, etc.
+    This function is crucial for identifying keywords for Wikipedia searches.
+
+    Args:
+        text (str): The input string.
+
+    Returns:
+        list[tuple[str, str]]: A list of tuples, where each tuple contains
+                                the entity text and its label (e.g., ("diabetes", "DISEASE")).
+                                Returns an empty list if input is not a string or if an error occurs.
     """
-    doc = nlp(text)
-    entities = [(ent.text, ent.label_) for ent in doc.ents]
+    if not isinstance(text, str):
+        print(f"Warning: extract_medical_entities_spacy received non-string input: {type(text)}. Returning empty list.")
+        return []
+    try:
+        doc = nlp(text)
+        entities = [(ent.text, ent.label_) for ent in doc.ents]
+    except Exception as e:
+        print(f"Error during spaCy entity extraction for text snippet '{text[:50]}...': {e}")
+        return []
     return entities
 
 if __name__ == "__main__":

--- a/reader.py
+++ b/reader.py
@@ -4,6 +4,19 @@ from config import QA_MODEL_NAME, QA_MODEL_PATH, DEVICE
 
 class QAModelReader:
     def __init__(self):
+        """
+        Initializes the QAModelReader.
+
+        Loads the Question Answering model and tokenizer from Hugging Face based
+        on configurations in `config.py`. It also sets up the QA pipeline
+        and determines model-specific parameters like max sequence length and stride
+        for context chunking.
+
+        The constructor will print loading status and relies on Hugging Face's
+        caching mechanism for model storage. If models are not found locally,
+        they will be downloaded. Errors during model download/loading from
+        Hugging Face Hub may cause program termination.
+        """
         print(f"Loading QA model: {QA_MODEL_NAME} to {DEVICE}...") 
         self.tokenizer = AutoTokenizer.from_pretrained(QA_MODEL_PATH)
         self.model = AutoModelForQuestionAnswering.from_pretrained(QA_MODEL_PATH).to(DEVICE) 
@@ -16,39 +29,212 @@ class QAModelReader:
             model=self.model,
             tokenizer=self.tokenizer,
             device=0 if DEVICE == "cuda" else -1 # 0 for first GPU, -1 for CPU
-        ) 
+        )
+        # It's good practice to define model_max_length and stride either from config or as class attributes if they are fixed.
+        # For now, let's use a common value for bert-based models or derive it.
+        self.model_max_length = self.tokenizer.model_max_length
+        # Define a reasonable stride, e.g., 1/4th of max length, or a fixed number like 128
+        # This stride is for the context tokens, not the combined (question+context) sequence.
+        self.doc_stride = self.model_max_length // 4
         print("QA model loaded.")
 
-    def extract_answer(self, question, context):
+    def extract_answer(self, question: str, context: str) -> tuple[str | None, float]:
         """
-        Extracts an answer span from the given context for the question. [cite: 217]
-        Returns the answer text, start, end, and confidence score.
+        Extracts an answer span from the given context for the question.
+
+        Handles long contexts by tokenizing the context and splitting it into
+        overlapping chunks if its length (plus question length) exceeds the
+        model's maximum sequence length. Each chunk is processed by the QA pipeline.
+        The answer with the highest confidence score across all chunks is returned.
+
+        Args:
+            question (str): The question string.
+            context (str): The context string from which to extract the answer.
+
+        Returns:
+            tuple[str | None, float]: A tuple containing the extracted answer text
+                                      (or None if no answer is found) and its
+                                      confidence score (0.0 if no answer).
         """
-        try:
-            # The pipeline handles tokenization, model inference, and span extraction
-            result = self.qa_pipeline(question=question, context=context) 
-            # result structure: {'score': float, 'start': int, 'end': int, 'answer': str}
-            return result['answer'], result['score'] 
-        except Exception as e:
-            print(f"Error during QA extraction for question '{question[:50]}...' and context '{context[:50]}...': {e}")
+        if not isinstance(question, str) or not isinstance(context, str):
+            print("Warning: extract_answer received non-string input for question or context.")
+            return None, 0.0
+        if not question.strip() or not context.strip():
+            print("Warning: extract_answer received empty question or context.")
             return None, 0.0
 
-    def extract_answers_from_pages(self, question, wikipedia_pages):
+        try:
+            # Tokenize the question to find its length (in tokens)
+            # We use encode to get IDs, not for direct input to pipeline here, but for length calculation.
+            # The tokenizer for the pipeline will add special tokens ([CLS], [SEP])
+            # For BERT: [CLS] question [SEP] context [SEP]
+            # Max tokens for context = model_max_length - (tokens in question) - 3 special tokens
+            question_input_ids = self.tokenizer.encode(question, add_special_tokens=False)
+
+            # Calculate available length for context in each chunk
+            # -3 for [CLS], [SEP] question [SEP] context [SEP]
+            # More accurately, the tokenizer when preparing for the model will handle special tokens.
+            # We should aim for context chunks that, when combined with the question by the pipeline's internal tokenizer,
+            # fit within self.model_max_length.
+            # A simpler approach for chunking text:
+            # Estimate max context tokens, then decode token chunks to text.
+
+            # Max length for the context part of the input
+            # The pipeline's internal tokenizer will add special tokens.
+            # For BERT: [CLS] Q_tokens [SEP] C_tokens [SEP].
+            # So, effective_max_len_for_context_tokens = self.model_max_length - len(question_input_ids) - 3 (approx for CLS, SEP, SEP)
+            # However, it's safer to let the pipeline tokenizer handle exact truncation or use its logic.
+            # The Hugging Face pipeline itself doesn't expose a simple way to process pre-split token IDs for context chunks
+            # while providing the question string separately. It expects context as a string.
+            # So, we chunk the context string.
+
+            context_tokens_ids = self.tokenizer.encode(context, add_special_tokens=False) # Get context token IDs without special tokens
+            num_context_tokens = len(context_tokens_ids)
+
+            # Estimate the max number of context tokens we can have in a single pass with the question
+            # This is a rough estimation to decide if chunking is needed.
+            # The pipeline will internally tokenize `question + context`.
+            # A single tokenized sequence for QA pipeline: [CLS] q_toks [SEP] c_toks [SEP]
+            # Max context tokens for one pass = model_max_length - question_tok_len - 3 (CLS, SEP, SEP)
+            # This is a simplified view. The tokenizer might have more complex logic for allocating space.
+            # Let's define max_chunk_context_tokens based on model_max_length, considering question length.
+            # The tokenizer used by the pipeline will truncate the context if (question + context) is too long.
+            # We want to avoid that truncation by feeding manageable context chunks.
+
+            # Define a max length for the text chunks of context we create.
+            # This is not the model_max_length directly, but a target for our context string chunks.
+            # The tokenizer inside the pipeline will later combine this chunk with the question.
+            # A practical approach: make context chunks somewhat smaller than model_max_length
+            # to ensure they fit with the question.
+            # Let's set chunk_target_token_length for context part.
+            # We use a chunk_token_length for context tokens, then decode to string.
+            # This should be less than model_max_length minus question length and special tokens.
+            # For simplicity, let's make context chunks of size (model_max_length - len(question_input_ids) - safety_margin)
+            # Safety margin for special tokens ([CLS], [SEP], [SEP]) and potential miscounts. Let's say 50 tokens.
+            # This logic is getting complicated. A fixed max_chunk_text_length might be more robust initially.
+            # Or, use the tokenizer's ability to work with strides if possible with string inputs.
+
+            # Simpler approach: If the full context (when tokenized with question) would be truncated, then chunk.
+            # The pipeline's tokenizer will truncate context if question + context > model_max_length.
+            # Let's use the example's manual token splitting idea for context.
+
+            # Max tokens the model can take for the context part, considering the question.
+            # This is the length of context tokens that can fit with the question and special tokens.
+            max_context_tokens_for_chunk = self.model_max_length - len(question_input_ids) - 3 # For [CLS], [SEP], [SEP]
+
+            if max_context_tokens_for_chunk <= 0: # Question itself is too long or near max_length
+                # Handle this edge case: maybe truncate question or return error.
+                # For now, try to proceed with a very small context allowance if possible,
+                # or rely on pipeline to error out if question itself is too long.
+                # A more robust way would be to check question length against model_max_length first.
+                print(f"Warning: Question might be too long for the model. Tokens: {len(question_input_ids)}")
+                # If question itself (plus special tokens) already exceeds max_seq_length,
+                # then no room for context. The pipeline will likely handle this by truncating the question or erroring.
+                # Let's assume the question fits, and max_context_tokens_for_chunk is the budget for context tokens.
+                # If max_context_tokens_for_chunk is very small (e.g. < stride), chunking might not be effective.
+                if max_context_tokens_for_chunk < self.doc_stride // 2 and num_context_tokens > max_context_tokens_for_chunk : # If context exists but allowance is too small
+                     print(f"Warning: Very small token allowance for context ({max_context_tokens_for_chunk}). May lead to poor chunking.")
+
+
+            if num_context_tokens > max_context_tokens_for_chunk:
+                all_chunk_results = []
+
+                # Ensure stride is less than the chunk capacity for context
+                current_stride = min(self.doc_stride, max_context_tokens_for_chunk - 1 if max_context_tokens_for_chunk > 0 else 0)
+                if current_stride <= 0 and num_context_tokens > 0 : # If context exists but stride is non-positive (e.g. question too long)
+                    current_stride = max_context_tokens_for_chunk // 2 # Fallback stride if possible
+                    if current_stride <=0 : # Still bad, means max_context_tokens_for_chunk is ~0 or 1.
+                         print(f"Error: Cannot process context due to extremely long question or model constraints. Context allowance: {max_context_tokens_for_chunk}")
+                         return None, 0.0
+
+
+                for i in range(0, num_context_tokens, max_context_tokens_for_chunk - current_stride):
+                    start_token = i
+                    end_token = min(i + max_context_tokens_for_chunk, num_context_tokens)
+
+                    chunk_token_ids = context_tokens_ids[start_token:end_token]
+                    # Decode back to string for the pipeline
+                    chunk_text = self.tokenizer.decode(chunk_token_ids, skip_special_tokens=True, clean_up_tokenization_spaces=True)
+
+                    if not chunk_text.strip(): # Avoid processing empty or whitespace-only chunks
+                        continue
+
+                    # Run pipeline on this chunk
+                    # The pipeline will tokenize `question` and `chunk_text` together here.
+                    # And it will handle truncation if, for some reason, this specific chunk + question is still too long.
+                    result = self.qa_pipeline(question=question, context=chunk_text)
+                    if result and result['answer']: # Ensure answer is not None or empty
+                        all_chunk_results.append(result)
+
+                if not all_chunk_results:
+                    return None, 0.0
+
+                # Select the best answer based on score
+                best_result = max(all_chunk_results, key=lambda x: x['score'])
+                return best_result['answer'], best_result['score']
+            else:
+                # Context is short enough, process as before
+                result = self.qa_pipeline(question=question, context=context)
+                return result['answer'], result['score']
+
+        except Exception as e:
+            # It's useful to log the question and a snippet of context for debugging
+            context_snippet = context[:100] + "..." if len(context) > 100 else context
+            question_snippet = question[:100] + "..." if len(question) > 100 else question
+            print(f"Error during QA extraction for question '{question_snippet}' and context snippet '{context_snippet}': {e}")
+            # Optionally, re-raise or handle more gracefully depending on application needs
+            # For robustness, especially with chunking, ensure we always return a tuple
+            return None, 0.0
+
+    def extract_answers_from_pages(self, question: str, wikipedia_pages: list[dict]) -> list[dict]:
         """
-        Extracts answers from a list of Wikipedia page dictionaries. [cite: 215]
-        wikipedia_pages: List of {"id": ..., "title": ..., "text": ...}
-        Returns a list of candidate answers with scores, e.g.,
-        [{"answer": "...", "score": ..., "source_page_title": "..."}, ...]
+        Extracts answers from a list of Wikipedia page dictionaries.
+
+        Iterates through each page, calls `extract_answer` for its text content,
+        and collects all found answers along with their scores and source page titles.
+        The results are sorted by confidence score in descending order.
+
+        Args:
+            question (str): The question string.
+            wikipedia_pages (list[dict]): A list of dictionaries, where each
+                                          dictionary represents a Wikipedia page and
+                                          must contain at least "text" and "title" keys.
+                                          Example: `[{"id": "...", "title": "...", "text": "..."}, ...]`
+
+        Returns:
+            list[dict]: A list of candidate answers, each as a dictionary:
+                        `{"answer": str, "score": float, "source_page_title": str}`.
+                        The list is sorted by score in descending order. Returns an
+                        empty list if no answers are found or if input is invalid.
         """
+        if not isinstance(question, str) or not question.strip():
+            print("Warning: extract_answers_from_pages received empty or invalid question. Returning empty list.")
+            return []
+        if not isinstance(wikipedia_pages, list):
+            print("Warning: extract_answers_from_pages received non-list input for wikipedia_pages. Returning empty list.")
+            return []
+
         candidate_answers = []
         for page in wikipedia_pages:
-            answer, score = self.extract_answer(question, page["text"])
-            if answer:
+            if not isinstance(page, dict) or "text" not in page or "title" not in page:
+                print(f"Warning: Skipping invalid page data in extract_answers_from_pages: {page}")
+                continue
+
+            page_text = page.get("text", "")
+            page_title = page.get("title", "Unknown Title")
+
+            if not isinstance(page_text, str) or not page_text.strip():
+                # print(f"Warning: Skipping page '{page_title}' with empty or invalid text content.")
+                continue # Silently skip pages with no text
+
+            answer, score = self.extract_answer(question, page_text)
+            if answer: # Ensure answer is not None and not an empty string (though pipeline usually returns None for no answer)
                 candidate_answers.append({
                     "answer": answer,
                     "score": score,
-                    "source_page_title": page["title"]
+                    "source_page_title": page_title
                 })
+
         # Sort by score for easier processing in answer_selector
         candidate_answers.sort(key=lambda x: x['score'], reverse=True)
         return candidate_answers

--- a/retriever.py
+++ b/retriever.py
@@ -5,14 +5,24 @@ from transformers import AutoTokenizer, AutoModel
 import torch
 import faiss
 import numpy as np
+from sklearn.feature_extraction.text import TfidfVectorizer # Added import
 from config import SENTENCE_TRANSFORMER_MODEL, SENTENCE_TRANSFORMER_MODEL_PATH, \
                    WIKIPEDIA_TITLE_EMBEDDINGS_PATH, WIKIPEDIA_TITLE_INDEX_PATH, \
                    WIKIPEDIA_TITLE_METADATA_PATH, DEVICE, WIKIPEDIA_SEARCH_RESULTS_TO_CONSIDER, \
                    MAX_WIKIPEDIA_PAGES_PER_QUESTION, WIKIPEDIA_CACHE_DIR, QA_MODEL_NAME, QA_MODEL_PATH
 from preprocessing import preprocess_text, extract_medical_entities_spacy
 
+# Define relevant entity types for query augmentation
+RELEVANT_ENTITY_TYPES = ["DISEASE", "DRUG", "ANATOMY", "PATHOLOGY", "PROCEDURE", "CHEMICAL"]
+
 class WikipediaRetriever:
     def __init__(self):
+        """
+        Initializes the WikipediaRetriever.
+
+        Loads the Sentence Transformer model for embeddings and ensures
+        the Wikipedia cache directory exists.
+        """
         print(f"Loading Sentence Transformer model to {DEVICE}...")
         self.tokenizer = AutoTokenizer.from_pretrained(SENTENCE_TRANSFORMER_MODEL_PATH)
         self.model = AutoModel.from_pretrained(SENTENCE_TRANSFORMER_MODEL_PATH).to(DEVICE)
@@ -24,24 +34,54 @@ class WikipediaRetriever:
         # Ensure cache directory exists
         os.makedirs(WIKIPEDIA_CACHE_DIR, exist_ok=True)
 
-    def _mean_pooling(self, model_output, attention_mask):
-        """Performs mean pooling to get sentence embeddings."""
-        token_embeddings = model_output[0]
-        input_mask_expanded = attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
-        return torch.sum(token_embeddings * input_mask_expanded, 1) / torch.clamp(input_mask_expanded.sum(1), min=1e-9)
+    def _mean_pooling(self, model_output: tuple, attention_mask: torch.Tensor) -> torch.Tensor:
+        """
+        Performs mean pooling on token embeddings to get sentence embeddings.
 
-    def get_embeddings(self, texts):
-        """Generates embeddings for a list of texts using the Sentence Transformer model."""
+        Args:
+            model_output (tuple): Output from the Hugging Face model, where the first element
+                                  (model_output[0]) contains token embeddings.
+            attention_mask (torch.Tensor): Attention mask for the input tokens.
+
+        Returns:
+            torch.Tensor: Sentence embeddings.
+        """
+        token_embeddings = model_output[0] # First element of model_output contains all token embeddings
+        input_mask_expanded = attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
+        sum_embeddings = torch.sum(token_embeddings * input_mask_expanded, 1)
+        sum_mask = torch.clamp(input_mask_expanded.sum(1), min=1e-9)
+        return sum_embeddings / sum_mask
+
+    def get_embeddings(self, texts: list[str]) -> np.ndarray:
+        """
+        Generates embeddings for a list of texts using the Sentence Transformer model.
+
+        Args:
+            texts (list[str]): A list of text strings to embed.
+
+        Returns:
+            np.ndarray: A NumPy array of sentence embeddings.
+        """
+        if not texts or not isinstance(texts, list):
+            return np.array([])
+
         encoded_input = self.tokenizer(texts, padding=True, truncation=True, return_tensors='pt').to(DEVICE)
         with torch.no_grad():
             model_output = self.model(**encoded_input)
         sentence_embeddings = self._mean_pooling(model_output, encoded_input['attention_mask'])
         return sentence_embeddings.cpu().numpy()
 
-    def _get_wikipedia_search_results(self, query):
+    def _get_wikipedia_search_results(self, query: str) -> list[dict]:
         """
-        Performs an online search using the Wikipedia API for page titles/summaries. [cite: 55]
-        Returns a list of dictionaries with 'title', 'pageid', 'snippet'.
+        Performs an online search using the Wikipedia API for page titles and snippets.
+
+        Args:
+            query (str): The search query string.
+
+        Returns:
+            list[dict]: A list of dictionaries, where each dictionary contains 'title',
+                        'pageid', and 'snippet' of a search result. Returns an empty
+                        list if the search fails or yields no results.
         """
         S = requests.Session()
         URL = "https://en.wikipedia.org/w/api.php"
@@ -69,16 +109,39 @@ class WikipediaRetriever:
                 return results
             return []
         except requests.exceptions.RequestException as e:
-            print(f"Error during Wikipedia API search for '{query}': {e}")
+            print(f"Error during Wikipedia API search for query '{query}': {e}")
+            return []
+        except json.JSONDecodeError as e:
+            print(f"Error decoding JSON response from Wikipedia API for query '{query}': {e}")
             return []
 
-    def _get_wikipedia_page_content(self, title):
+
+    def _get_wikipedia_page_content(self, title: str) -> str:
         """
-        Downloads the full plain text content of a Wikipedia page. [cite: 55]
-        Caches content locally.
+        Downloads the full plain text content of a Wikipedia page by its title.
+
+        The content is cached locally in the `WIKIPEDIA_CACHE_DIR` to avoid
+        re-downloading on subsequent requests for the same page.
+
+        Args:
+            title (str): The title of the Wikipedia page.
+
+        Returns:
+            str: The plain text content of the page. Returns an empty string if
+                 the page cannot be fetched or content is not available.
         """
+        if not isinstance(title, str) or not title.strip():
+            print("Warning: _get_wikipedia_page_content received invalid title. Returning empty string.")
+            return ""
+
         # Check cache first
-        cached_filepath = os.path.join(WIKIPEDIA_CACHE_DIR, f"{title.replace(' ', '_')}.txt")
+        # Sanitize title for use as a filename
+        safe_filename = title.replace(' ', '_').replace('/', '_').replace('\\', '_')
+        # Limit filename length to avoid OS errors
+        max_filename_len = 200 # Conservative limit
+        safe_filename = safe_filename[:max_filename_len]
+
+        cached_filepath = os.path.join(WIKIPEDIA_CACHE_DIR, f"{safe_filename}.txt")
         if os.path.exists(cached_filepath):
             with open(cached_filepath, 'r', encoding='utf-8') as f:
                 return f.read()
@@ -108,7 +171,10 @@ class WikipediaRetriever:
                         f.write(page_content)
             return page_content
         except requests.exceptions.RequestException as e:
-            print(f"Error during Wikipedia API content fetch for '{title}': {e}")
+            print(f"Error during Wikipedia API content fetch for title '{title}': {e}")
+            return ""
+        except json.JSONDecodeError as e:
+            print(f"Error decoding JSON response from Wikipedia API for title '{title}': {e}")
             return ""
 
     def build_title_index(self):
@@ -166,45 +232,168 @@ class WikipediaRetriever:
             self.wiki_title_metadata = json.load(open(WIKIPEDIA_TITLE_METADATA_PATH, 'r', encoding='utf-8'))
             print("Wikipedia title index loaded.")
             return True
-        except FileNotFoundError as e:
-            print(f"Wikipedia title index not found: {e}. Please build it first.")
+    except FileNotFoundError:
+        print(f"Wikipedia title index not found at {WIKIPEDIA_TITLE_INDEX_PATH} or {WIKIPEDIA_TITLE_METADATA_PATH}. Please build it first or check paths.")
+        return False
+    except json.JSONDecodeError as e:
+        print(f"Error decoding JSON for Wikipedia title metadata from {WIKIPEDIA_TITLE_METADATA_PATH}: {e}")
             return False
         except Exception as e:
-            print(f"Error loading Wikipedia title index: {e}")
+        print(f"An unexpected error occurred while loading Wikipedia title index: {e}")
             return False
 
-    def retrieve_pages(self, query_text):
-        """
-        Performs semantic search for Wikipedia titles, downloads top 5 pages.
-        """
-        # Step 1: Formulate search query using preprocessed text and extracted entities
-        # A simple approach: use the preprocessed question text as the query
-        search_query = preprocess_text(query_text)
-        entities = extract_medical_entities_spacy(query_text)
-        if entities:
-            # Augment query with key entities if relevant
-            search_query += " " + " ".join([ent[0] for ent in entities if ent[1] in ["DISEASE", "DRUG", "ANATOMY"]])
-        
-        print(f"Searching Wikipedia for: '{search_query}'")
 
-        # Step 2: Use Wikipedia API for initial search (online step)
-        search_results = self._get_wikipedia_search_results(search_query)
-        if not search_results:
-            print("No search results from Wikipedia API.")
+    def _get_tfidf_keywords(self, text: str, top_n: int = 5) -> list[str]:
+        """
+        Extracts top_n keywords from text using TF-IDF.
+        Uses preprocessing with lemmatization.
+        """
+        # Use original text for TF-IDF, preprocessing (including lemmatization) is done here
+        preprocessed_text_for_tfidf = preprocess_text(text, perform_lemmatization=True)
+        if not preprocessed_text_for_tfidf.strip(): # Check if empty after preprocessing
             return []
 
-        # Step 3: Embed search results (titles + snippets) and query, then rank using FAISS
+        try:
+            vectorizer = TfidfVectorizer(stop_words='english', ngram_range=(1, 2), max_df=0.95, min_df=1)
+            tfidf_matrix = vectorizer.fit_transform([preprocessed_text_for_tfidf])
+            feature_names = vectorizer.get_feature_names_out()
+
+            if feature_names.size == 0: # Check if feature_names is empty (e.g. text was only stopwords)
+                return []
+
+            scores = tfidf_matrix.toarray().flatten()
+
+            sorted_indices = np.argsort(scores)[::-1]
+
+            top_keywords = []
+            # Iterate up to top_n or fewer if not enough terms meet criteria
+            for i in sorted_indices:
+                if len(top_keywords) >= top_n:
+                    break
+                # Add a score threshold if needed, e.g. scores[i] > 0.1
+                if scores[i] > 0.0: # Basic check to ensure term has a score
+                     top_keywords.append(feature_names[i])
+            return top_keywords
+        except ValueError as e: # Catches errors like empty vocabulary
+            print(f"TF-IDF ValueError for input text snippet '{text[:50]}...': {e}")
+            return []
+
+    def retrieve_pages(self, query_text: str) -> list[dict]:
+        """
+        Retrieves relevant Wikipedia pages for a given query text.
+
+        The process involves:
+        1. Preprocessing the query text.
+        2. Augmenting the query with Named Entities (NER) and TF-IDF keywords.
+        3. Searching Wikipedia using its API with the augmented query.
+        4. Embedding the search results (titles + snippets) and the original query's
+           base form (`base_s_query`).
+        5. Re-ranking the search results based on semantic similarity between the
+           query embedding and result embeddings.
+        6. Fetching the full text content of the top-ranked, unique pages.
+        7. Caching downloaded page content.
+
+        Args:
+            query_text (str): The input question or query.
+
+        Returns:
+            list[dict]: A list of dictionaries, where each dictionary represents a
+                        retrieved Wikipedia page and contains its 'id', 'title', and
+                        'text'. Returns an empty list if no relevant pages are found
+                        or if an error occurs during the process.
+        """
+        if not isinstance(query_text, str) or not query_text.strip():
+            print("Warning: retrieve_pages received empty or invalid query_text. Returning empty list.")
+            return []
+
+        # Step 1: Formulate search query
+        # Base query: less aggressive preprocessing (e.g., no lemmatization for main search query to Wikipedia)
+        base_s_query = preprocess_text(query_text, perform_lemmatization=False)
+
+        # NER Entities from original query_text
+        entities_tuples = extract_medical_entities_spacy(query_text)
+        # Get unique, lowercased entity texts from specified types
+        ner_entities_texts = list(set([ent[0].lower() for ent in entities_tuples if ent[1] in RELEVANT_ENTITY_TYPES]))
+
+        # TF-IDF Keywords from original query_text (preprocessing is internal to _get_tfidf_keywords)
+        tfidf_keywords = self._get_tfidf_keywords(query_text, top_n=3) # top_n=3 for fewer, high-quality terms
+
+        # Combine terms for the final search query for Wikipedia API
+        # Start with base query terms (split, lowercased for set operations)
+        final_query_terms = base_s_query.lower().split()
+        existing_terms_set = set(final_query_terms) # Keep track of terms already added
+
+        # Add NER entities (if not already present from base query)
+        for term in ner_entities_texts: # ner_entities_texts are already lowercased
+            if term not in existing_terms_set:
+                final_query_terms.append(term)
+                existing_terms_set.add(term)
+
+        # Add TF-IDF keywords (if not already present)
+        for term in tfidf_keywords: # tfidf_keywords can be mixed case
+            term_lower = term.lower()
+            if term_lower not in existing_terms_set:
+                final_query_terms.append(term_lower)
+                existing_terms_set.add(term_lower)
+
+        search_query_for_api = " ".join(final_query_terms)
+        
+        # Logging the components of the query for transparency
+        print(f"Original Query: '{query_text}'")
+        print(f"Base Search Query (for API and embedding): '{base_s_query}'")
+        print(f"NER Entities (lower, unique): {ner_entities_texts}")
+        print(f"TF-IDF Keywords (raw, top_n=3): {tfidf_keywords}")
+        print(f"Final Augmented Wikipedia Search Query (for API): '{search_query_for_api}'")
+
+        # Step 2: Use Wikipedia API for initial search (online step)
+        search_results = self._get_wikipedia_search_results(search_query_for_api)
+        if not search_results:
+            print("No search results from Wikipedia API for augmented query.")
+            return []
+
+        # Step 3: Embed search results (titles + snippets) and query, then rank
+        # The query to embed for semantic ranking should be 'base_s_query' (preprocessed original query),
+        # as it represents the core intent better than the keyword-stuffed 'search_query_for_api'.
+        query_embedding_text = base_s_query
+
         result_texts = [f"{s['title']} {s['snippet']}" for s in search_results]
-        result_embeddings = self.get_embeddings(result_texts)
-        query_embedding = self.get_embeddings([search_query])
+
+        if not result_texts: # Handle empty result_texts before attempting to get embeddings
+            print("No text from search results to embed. Skipping ranking.")
+            ranked_indices = [] # Ensure ranked_indices is defined
+            result_embeddings = np.array([]) # Ensure result_embeddings is defined
+            query_embedding = self.get_embeddings([query_embedding_text]) # Still embed query for consistency if needed later
+        else:
+            result_embeddings = self.get_embeddings(result_texts)
+            query_embedding = self.get_embeddings([query_embedding_text])
 
         # If FAISS index is not built from a comprehensive set of titles,
         # we can do a direct similarity search against the current search results.
         # For a full FAISS index for titles, you'd perform a search on self.faiss_index.
         
-        # Here, we'll re-rank the `search_results` using semantic similarity to the query
-        similarities = np.dot(query_embedding, result_embeddings.T).flatten()
-        ranked_indices = np.argsort(similarities)[::-1] # Get indices of highest similarity first
+        # Here, we'll re-rank the `search_results` using semantic similarity to the query.
+        # Ensure query_embedding is 2D array for dot product.
+        if query_embedding.ndim == 1:
+            query_embedding = np.expand_dims(query_embedding, axis=0)
+
+        # Ensure result_embeddings is also 2D, even if only one result.
+        if result_embeddings.ndim == 1 and result_embeddings.size > 0 : # Check size to avoid issues with np.array([])
+             result_embeddings = np.expand_dims(result_embeddings, axis=0)
+
+        # Check if result_embeddings is empty or not 2D before dot product
+        if not isinstance(result_embeddings, np.ndarray) or result_embeddings.ndim != 2 or result_embeddings.shape[0] == 0:
+            print("No valid embeddings generated for search results. Skipping ranking.")
+            # If no valid embeddings, we might take results as they came from API, or return empty.
+            # For now, proceed with empty ranked_indices, meaning no pages selected based on semantic similarity.
+            ranked_indices = []
+        else:
+            try:
+                similarities = np.dot(query_embedding, result_embeddings.T).flatten()
+                ranked_indices = np.argsort(similarities)[::-1] # Get indices of highest similarity first
+            except ValueError as e:
+                print(f"Error during similarity calculation (np.dot): {e}. Shapes: query_embedding={query_embedding.shape}, result_embeddings={result_embeddings.shape}")
+                ranked_indices = []
+
 
         retrieved_articles = []
         seen_titles = set()

--- a/utils.py
+++ b/utils.py
@@ -3,20 +3,44 @@ import os
 import random
 import numpy as np
 import torch
-import config
+# import config # config is not used directly for RANDOM_SEED anymore
 
-def setup_logging(level=logging.INFO):
-    """Sets up basic logging."""
-    logging.basicConfig(level=level, format='%(asctime)s - %(levelname)s - %(message)s')
+def setup_logging(level: int = logging.INFO):
+    """
+    Sets up basic logging for the application.
+
+    Args:
+        level (int, optional): The logging level (e.g., logging.INFO, logging.DEBUG).
+                               Defaults to logging.INFO.
+    """
+    logging.basicConfig(level=level,
+                        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+                        datefmt='%Y-%m-%d %H:%M:%S')
 
 def ensure_dir(directory_path: str):
-    """Ensures that a directory exists, creating it if necessary."""
-    if not os.path.exists(directory_path):
-        os.makedirs(directory_path)
-        logging.info(f"Created directory: {directory_path}")
+    """
+    Ensures that a directory exists at the specified path.
+    If the directory (or any parent directory) does not exist, it is created.
 
-def set_seed(seed: int = config.RANDOM_SEED):
-    """Sets random seed for reproducibility."""
+    Args:
+        directory_path (str): The path to the directory.
+    """
+    if not os.path.exists(directory_path):
+        try:
+            os.makedirs(directory_path)
+            logging.info(f"Created directory: {directory_path}")
+        except OSError as e:
+            logging.error(f"Error creating directory {directory_path}: {e}")
+            # Depending on severity, might re-raise or handle differently
+            raise # Re-raise the exception if directory creation is critical
+
+def set_seed(seed: int = 42):
+    """
+    Sets random seeds for Python's `random`, NumPy, and PyTorch to ensure reproducibility.
+
+    Args:
+        seed (int, optional): The seed value to use. Defaults to 42.
+    """
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)


### PR DESCRIPTION
I've implemented a multi-stage RAG pipeline for medical question answering using the MedQA dataset and live Wikipedia fetching.

Key features:
- Retriever: I dynamically search Wikipedia using its API, augment queries with NER (spaCy) and TF-IDF keywords, rank search results using semantic similarity (Sentence Transformers), and fetch content for the top 5 pages per question. I've included local caching for Wikipedia pages.
- Reader: I use an extractive QA model (DistilBERT-SQuAD) to identify answer spans from retrieved Wikipedia articles. I've implemented document chunking to handle long articles, processing them in overlapping segments.
- Answer Selector: I compare candidate answers from the Reader to the multiple-choice options from MedQA using exact match, fuzzy matching, and semantic similarity, then select the best option.
- Orchestration (`main.py`): I manage the full pipeline, including dataset loading (Hugging Face MedQA), model pre-downloading and loading (Sentence Transformers, QA model, spaCy), subset evaluation, and error handling.
- Preprocessing: I've included text cleaning, tokenization, stopword removal, lemmatization, and NER with spaCy.
- Evaluation: I calculate and report accuracy.
- Configuration: I've centralized settings in `config.py`.
- Documentation: I've added `README.md` with setup, execution instructions, and module descriptions.
- Code Quality: I've improved docstrings (NumPy style), added type hints, and enhanced error handling across modules.

The system is designed to download and use local models for reproducibility. The Wikipedia retrieval is performed live, per question.

Note: I was not able to perform end-to-end testing due to disk space limitations for installing all dependencies. You will perform testing in your own environment.